### PR TITLE
Add getPathToPage method

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 func main() {
@@ -27,8 +29,9 @@ type Link struct {
 }
 
 type Page struct {
-	Title string `json:"title"`
-	Links []Link `json:"links"`
+	Title  string `json:"title"`
+	Links  []Link `json:"links"`
+	Parent *Page
 }
 
 func (p *Page) articles() []string {
@@ -41,6 +44,18 @@ func (p *Page) articles() []string {
 	return articles
 }
 
+func (p *Page) GetHierarchy() []string {
+	path := []string{}
+	currentPage := p
+
+	for currentPage != nil {
+		path = append(path, currentPage.Title)
+		currentPage = currentPage.Parent
+	}
+
+	return path
+}
+
 type WikiQuery struct {
 	Pages map[string]Page `json:"pages"`
 }
@@ -48,6 +63,12 @@ type WikiQuery struct {
 type WikiResponse struct {
 	Query WikiQuery `json:"query"`
 }
+
+type Fetcher interface {
+	FetchPage(string, string) ([]string, error)
+}
+
+type WikiFetcher struct{}
 
 func (wq *WikiQuery) articles() []string {
 	articles := []string{}
@@ -62,9 +83,9 @@ func (wr *WikiResponse) articles() []string {
 	return wr.Query.articles()
 }
 
-func fetchPage(wikiUrl string, pageName string) ([]string, error) {
+func (fetcher *WikiFetcher) FetchPage(wikiURL string, pageName string) ([]string, error) {
 	query := buildQuery(pageName)
-	url := fmt.Sprintf("%s%s", wikiUrl, query)
+	url := fmt.Sprintf("%s%s", wikiURL, query)
 	res, err := http.Get(url)
 	defer res.Body.Close()
 	if err != nil {
@@ -85,4 +106,33 @@ func fetchPage(wikiUrl string, pageName string) ([]string, error) {
 	articles := wikiResponse.articles()
 
 	return articles, nil
+}
+
+func getPathToPage(fetcher Fetcher, wikiURL string, startingPage string, endingPage string) ([]string, error) {
+	rootPage := Page{startingPage, nil, nil}
+
+	// Space, the final frontier
+	frontier := []Page{rootPage}
+
+	for len(frontier) > 0 {
+		children := []Page{}
+
+		for i, page := range frontier {
+			childrenTitles, _ := fetcher.FetchPage(wikiURL, page.Title)
+
+			for _, childTitle := range childrenTitles {
+				childPage := Page{Title: childTitle, Parent: &frontier[i]}
+
+				if strings.ToLower(childTitle) == strings.ToLower(endingPage) {
+					return childPage.GetHierarchy(), nil
+				}
+
+				children = append(children, childPage)
+			}
+		}
+
+		frontier = children
+	}
+
+	return nil, errors.New("No more references could be found.")
 }


### PR DESCRIPTION
This adds the `getPathToPage` method, which is responsible for doing a breadth-first search until it finds the desired `endingPage`.

Things I'd like to have you review with doubled attention:

---------------

### [This line](https://github.com/FloripaCodeAndMagic/sete-passos-para-as-estrelas/compare/get-path-to-page?expand=1#diff-7ddfb3e035b42cd70649cc33393fe32cR124) which gets a reference to the item in the `frontier`

I spent hours understanding why I could not use `&page` here, and that's because any assignments in Go are copies. This means that `&page` would always reference the address of `page` itself (which changes as we iterate over it).

By using `&frontier[i]` I'm able to get the reference to the real item, however I'm afraid here that our test does not catch failing cases. Is it possible that by using `&frontier[i]` I'm always getting a reference to that same index in `frontier` instead of the element inside of it?

---------------

### [This new recursive prop in our `Page` data structure](https://github.com/FloripaCodeAndMagic/sete-passos-para-as-estrelas/compare/get-path-to-page?expand=1#diff-7ddfb3e035b42cd70649cc33393fe32cR34)

Should I have added a new `struct` for it instead of reusing this one?

----------------

### [The way I've added the `FetchPage` method to an interface in order to mock it](https://github.com/FloripaCodeAndMagic/sete-passos-para-as-estrelas/compare/get-path-to-page?expand=1#diff-7ddfb3e035b42cd70649cc33393fe32cR67)

In order to test this in isolation I had to add the `FetchPage` method to an interface and then pass a struct instance that implements to the `getPathToPage` method.

My mock implementation just gets the desired return values from a map and returns it.

Do you think this could be improved.

**Thanks for reviewing 🤗**